### PR TITLE
CDKv2 Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 chalice.out
 **/.chalice/deployments/
 **/.chalice/venv/
-venv/
+*venv/
 .aws-sam
 .idea/
 .vscode

--- a/source/mre-fan-experience-frontend/cdk/app.py
+++ b/source/mre-fan-experience-frontend/cdk/app.py
@@ -1,10 +1,10 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 
-from aws_cdk import core
+from aws_cdk import App
 from stacks.mre_fan_experience_frontend_stack import MreFanExperienceFrontendStack
 
-app = core.App()
+app = App()
 
 MreFanExperienceFrontendStack(app, "mre-fan-experience-frontend-stack")
 

--- a/source/mre-fan-experience-frontend/cdk/cdk.json
+++ b/source/mre-fan-experience-frontend/cdk/cdk.json
@@ -1,8 +1,3 @@
 {
-  "app": "python3 app.py",
-  "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true"
-  }
+  "app": "python3 app.py"
 }

--- a/source/mre-fan-experience-frontend/cdk/requirements.txt
+++ b/source/mre-fan-experience-frontend/cdk/requirements.txt
@@ -1,6 +1,5 @@
-aws-cdk.aws_iam>=1.85.0,<2.0
-aws_cdk.aws_cognito>=1.85.0,<2.0
-aws_cdk.aws_codecommit>=1.85.0,<2.0
-aws_cdk.aws_amplify>=1.85.0,<2.0
+aws-cdk-lib>=2.24.1,<3.0
+aws-cdk.aws-amplify-alpha>=2.24.1a0,<3.0
+constructs>=10.0.0
 boto3<2.0.0
 git-remote-codecommit

--- a/source/mre-fan-experience-frontend/cdk/stacks/mre_fan_experience_frontend_stack.py
+++ b/source/mre-fan-experience-frontend/cdk/stacks/mre_fan_experience_frontend_stack.py
@@ -1,17 +1,19 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
-
+from constructs import Construct
 from aws_cdk import (
-    core,
+    CfnOutput,
+    CfnParameter,
+    Stack,
     aws_iam,
     aws_codecommit,
-    aws_amplify,
+    aws_amplify_alpha as aws_amplify,
     aws_cognito
 )
 
 
-class MreFanExperienceFrontendStack(core.Stack):
-    def __init__(self, scope: core.Construct, id: str, **kwargs) -> None:
+class MreFanExperienceFrontendStack(Stack):
+    def __init__(self, scope: Construct, id: str, **kwargs) -> None:
         super().__init__(scope, id, **kwargs)
 
         # region Cognito
@@ -20,7 +22,7 @@ class MreFanExperienceFrontendStack(core.Stack):
             user_pool_name="MRE-fan-experience-frontend"
         )
 
-        admin_email = core.CfnParameter(self, "adminemail", type="String")
+        admin_email = CfnParameter(self, "adminemail", type="String")
 
         aws_cognito.CfnUserPoolUser(
             self, "CognitoUser",
@@ -105,11 +107,11 @@ class MreFanExperienceFrontendStack(core.Stack):
 
         # endregion App
 
-        core.CfnOutput(self, "webAppURL", value="master." + app.default_domain)
-        core.CfnOutput(self, "webAppId", value=app.app_id)
-        core.CfnOutput(self, "region", value=self.region)
-        core.CfnOutput(self, "userPoolId", value=user_pool.user_pool_id)
-        core.CfnOutput(self, "appClientId", value=user_pool_client.user_pool_client_id)
-        core.CfnOutput(self, "identityPoolId", value=identity_pool.ref)
+        CfnOutput(self, "webAppURL", value="master." + app.default_domain)
+        CfnOutput(self, "webAppId", value=app.app_id)
+        CfnOutput(self, "region", value=self.region)
+        CfnOutput(self, "userPoolId", value=user_pool.user_pool_id)
+        CfnOutput(self, "appClientId", value=user_pool_client.user_pool_client_id)
+        CfnOutput(self, "identityPoolId", value=identity_pool.ref)
 
 

--- a/source/mre-plugin-samples/cdk/app.py
+++ b/source/mre-plugin-samples/cdk/app.py
@@ -3,10 +3,10 @@
 
 #!/usr/bin/env python3
 
-from aws_cdk import core as cdk
+from aws_cdk import App
 from stacks.mre_plugins_stack import MrePluginsStack
 
-app = cdk.App()
+app = App()
 MrePluginsStack(app, "aws-mre-plugin-samples")
 
 app.synth()

--- a/source/mre-plugin-samples/cdk/cdk.json
+++ b/source/mre-plugin-samples/cdk/cdk.json
@@ -1,18 +1,3 @@
 {
-  "app": "python3 app.py",
-  "context": {
-    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
-    "@aws-cdk/core:enableStackNameDuplicates": true,
-    "aws-cdk:enableDiffNoFail": true,
-    "@aws-cdk/core:stackRelativeExports": true,
-    "@aws-cdk/aws-ecr-assets:dockerIgnoreSupport": true,
-    "@aws-cdk/aws-secretsmanager:parseOwnedSecretName": true,
-    "@aws-cdk/aws-kms:defaultKeyPolicies": true,
-    "@aws-cdk/aws-s3:grantWriteWithoutAcl": true,
-    "@aws-cdk/aws-ecs-patterns:removeDefaultDesiredCount": true,
-    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
-    "@aws-cdk/aws-efs:defaultEncryptionAtRest": true,
-    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
-    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true
-  }
+  "app": "python3 app.py"
 }

--- a/source/mre-plugin-samples/cdk/requirements.txt
+++ b/source/mre-plugin-samples/cdk/requirements.txt
@@ -1,6 +1,5 @@
-aws-cdk.core>=1.85.0,<2.0
-aws-cdk.aws-iam>=1.85.0,<2.0
-aws-cdk.aws-lambda>=1.85.0,<2.0
+aws-cdk-lib>=2.24.1,<3.0
+constructs>=10.0.0
 boto3<2.0.0
 urllib3
 requests

--- a/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/app.py
+++ b/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/app.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT-0
 
 #!/usr/bin/env python3
-from aws_cdk import core as cdk
+from aws_cdk import App
 from stacks.chaliceapp import ChaliceApp
 
-app = cdk.App()
+app = App()
 ChaliceApp(app, 'aws-mre-samples-hls-harvester')
 
 app.synth()

--- a/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/cdk.json
+++ b/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/cdk.json
@@ -1,8 +1,3 @@
 {
-  "app": "python3 app.py",
-  "context": {
-    "@aws-cdk/core:enableStackNameDuplicates": "true",
-    "aws-cdk:enableDiffNoFail": "true",
-    "@aws-cdk/core:stackRelativeExports": "true"
-  }
+  "app": "python3 app.py"
 }

--- a/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/requirements.txt
+++ b/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/requirements.txt
@@ -1,3 +1,2 @@
-aws_cdk.core>=1.85.0,<2.0
-aws_cdk.aws_iam>=1.85.0,<2.0
-chalice[cdk]
+aws-cdk-lib>=2.24.1,<3.0
+chalice[cdkv2]

--- a/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/stacks/chaliceapp.py
+++ b/source/mre-video-ingestion-samples/HLS_Harvester/infrastructure/stacks/chaliceapp.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 from aws_cdk import (
-    core as cdk,
+    Stack,
     aws_iam as iam
 )
 from chalice.cdk import Chalice
@@ -21,7 +21,7 @@ RUNTIME_SOURCE_DIR = os.path.join(
     os.path.dirname(os.path.dirname(__file__)), os.pardir, 'runtime')
 
 
-class ChaliceApp(cdk.Stack):
+class ChaliceApp(Stack):
 
     def __init__(self, scope, id, **kwargs):
         super().__init__(scope, id, **kwargs)
@@ -41,7 +41,7 @@ class ChaliceApp(cdk.Stack):
                     "execute-api:Invoke",
                     "execute-api:ManageConnections"
                 ],
-                resources=[f"arn:aws:execute-api:{cdk.Stack.of(self).region}:{cdk.Stack.of(self).account}:*"]
+                resources=[f"arn:aws:execute-api:{Stack.of(self).region}:{Stack.of(self).account}:*"]
             )
         )
 
@@ -53,7 +53,7 @@ class ChaliceApp(cdk.Stack):
                     "ssm:DescribeParameters",
                     "ssm:GetParameter*"
                 ],
-                resources=[f"arn:aws:ssm:{cdk.Stack.of(self).region}:{cdk.Stack.of(self).account}:parameter/MRE*"]
+                resources=[f"arn:aws:ssm:{Stack.of(self).region}:{Stack.of(self).account}:parameter/MRE*"]
             )
         )
 
@@ -65,7 +65,7 @@ class ChaliceApp(cdk.Stack):
                     "sqs:DeleteMessage",
                     "sqs:ReceiveMessage"
                 ],
-                resources=[f"arn:aws:sqs:{cdk.Stack.of(self).region}:{cdk.Stack.of(self).account}:{harvester_config.SQS_QUEUE_URL.split('/')[-1]}"]
+                resources=[f"arn:aws:sqs:{Stack.of(self).region}:{Stack.of(self).account}:{harvester_config.SQS_QUEUE_URL.split('/')[-1]}"]
             )
         )
 


### PR DESCRIPTION
[Due to CDKv1 End-of-Support ](https://github.com/aws/aws-cdk-rfcs/blob/master/text/0079-cdk-2.0.md#aws-cdk-maintenance-policy)& [completed migration of MRE-core in latest release](https://github.com/awslabs/aws-media-replay-engine/releases), this PR contains the migration of the following stacks to CDKv2:
- MreFanExperienceFrontendStack
- MrePluginsStack
- HLS_Harvester Stack

