### PR TITLE
Fix/error by converting video format in DetectShotsByRekognitionVideo.py

### DIFF
--- a/source/mre-plugin-samples/Plugins/DetectShotsByRekognitionVideo/DetectShotsByRekognitionVideo.py
+++ b/source/mre-plugin-samples/Plugins/DetectShotsByRekognitionVideo/DetectShotsByRekognitionVideo.py
@@ -297,7 +297,7 @@ def lambda_handler(event, context):
         try:
             stream = ffmpeg.input(media_path)
             out, err = (
-                ffmpeg.output(stream,mp4_path)
+                ffmpeg.output(stream,mp4_path,vcodec='copy')
                 .run(capture_stdout=True, capture_stderr=True,overwrite_output=True)
             )
         except ffmpeg.Error as err:

--- a/source/mre-plugin-samples/Plugins/DetectShotsByRekognitionVideo/DetectShotsByRekognitionVideo.py
+++ b/source/mre-plugin-samples/Plugins/DetectShotsByRekognitionVideo/DetectShotsByRekognitionVideo.py
@@ -9,6 +9,8 @@ import ffmpeg
 from MediaReplayEnginePluginHelper import OutputHelper
 from MediaReplayEnginePluginHelper import Status
 from MediaReplayEnginePluginHelper import DataPlane
+from botocore.exceptions import ClientError
+
 s3_client = boto3.client('s3')
 
 class VideoDetect:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
When I combined DetectShotsByRekognitionVideo.py with the [media-replay-engine](https://github.com/awslabs/aws-media-replay-engine) and tried to  run it, the video format was converted to mpeg-4 by `ffmpeg.output(stream, mp4_path)` and an error occurred in later process.

In ffmpeg used in the [media-replay-engine](https://github.com/awslabs/aws-media-replay-engine) library, the`libx264` and `h264` libraries for converting videos to H.264 format have been removed due to capacity restrictions. Therefore, since an error occurs when vcodec="h264”, it works properly only by setting vcodec="copy” on the assumption that it is an H.264 format video input.

Also, clientError was not imported, and an error occurred in the part where the error occurred, so it was fixed. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.